### PR TITLE
Notify user on successful builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,14 @@ var path = require('path');
 module.exports = {
   name: 'ember-cli-build-notifications',
 
+  postBuild: function(results) {
+    notifier.notify({
+      title: 'Build Succeeded',
+      message: 'Build Time: ' + Math.round(results.totalTime/1000000) + 'ms',
+      appIcon: path.resolve(__dirname + '/ember-logo.png')
+    });
+  },
+
   buildError: function(error) {
     notifier.notify({
       title: 'Build Failed',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-build-notifications",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Notifications when ember-cli has a buildError",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Adding this new feature will allow developers to get a growl notification on build success so they don't have to switch back to the terminal to confirm a build is complete.