### PR TITLE
Allow passing of arbitrary options to node-notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,21 @@ To override defaults, add the following to the config file `{app}/config/build-n
 ```
 module.exports = {
   buildError: {
-    notify: true
+    notify: true,
+    notificationOptions: {
+      sound: true
+    }
   },
   buildSuccess: {
-    notify: true
+    notify: true,
+    notificationOptions: {
+      sound: true
+    }
   }
 };
 ```
 
+The `notificationOptions` settings are passed directly into node-notifier, see their [docs](https://github.com/mikaelbr/node-notifier#all-notification-options-with-their-defaults) for a full list of available settings
 
 ## Requirements
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
     var config = Config.load(this.project.root);
 
     if (config.buildError.notify) {
-      notifier.buildError(error);
+      notifier.buildError(error, config.buildError.options);
     }
   },
 
@@ -19,7 +19,7 @@ module.exports = {
     var config = Config.load(this.project.root);
 
     if (config.buildSuccess.notify) {
-      notifier.buildSuccess(results);
+      notifier.buildSuccess(results, config.buildSuccess.options);
     }
   }
 };

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
     var config = Config.load(this.project.root);
 
     if (config.buildError.notify) {
-      notifier.buildError(error, config.buildError.options);
+      notifier.buildError(error, config.buildError);
     }
   },
 
@@ -19,7 +19,7 @@ module.exports = {
     var config = Config.load(this.project.root);
 
     if (config.buildSuccess.notify) {
-      notifier.buildSuccess(results, config.buildSuccess.options);
+      notifier.buildSuccess(results, config.buildSuccess);
     }
   }
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,27 +1,16 @@
 /* jshint node: true */
 var fs = require('fs');
 var path = require('path');
-
-var merge = function(defaults, attrs) {
-  for (var key in attrs) {
-    if (attrs.hasOwnProperty(key)) {
-      if (typeof attrs[key] === 'object') {
-        defaults[key] = merge(defaults[key], attrs[key]);
-      } else {
-        defaults[key] = attrs[key];
-      }
-    }
-  }
-
-  return defaults;
-};
+var merge = require('./merge');
 
 var defaults = {
   buildError: {
-    notify: true
+    notify: true,
+    notificationOptions: {}
   },
   buildSuccess: {
-    notify: false
+    notify: false,
+    notificationOptions: {}
   }
 };
 

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -1,0 +1,16 @@
+/* jshint node: true */
+var merge = function(defaults, attrs) {
+  for (var key in attrs) {
+    if (attrs.hasOwnProperty(key)) {
+      if (typeof attrs[key] === 'object') {
+        defaults[key] = merge(defaults[key], attrs[key]);
+      } else {
+        defaults[key] = attrs[key];
+      }
+    }
+  }
+
+  return defaults;
+};
+
+module.exports = merge;

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -1,28 +1,35 @@
 /* jshint node: true */
 var nodeNotifier = require('node-notifier');
 var path = require('path');
+var merge = require('./merge');
 
 module.exports = {
   name: 'notifier',
 
   buildSuccess: function(results, options) {
     var notifier = (options && options.notifier) || nodeNotifier;
-
-    return notifier.notify({
+    var notificationOptions = {
       title: 'Build Succeeded',
       message: 'Build Time: ' + Math.round(results.totalTime/1000000) + 'ms',
       appIcon: path.resolve(__dirname, '..', 'ember-logo.png')
-    });
+    };
+    if(options && options.notificationOptions) {
+      notificationOptions = merge(notificationOptions, options.notificationOptions);
+    }
+    return notifier.notify(notificationOptions);
   },
 
   buildError: function(error, options) {
     var notifier = (options && options.notifier) || nodeNotifier;
-
-    return notifier.notify({
+    var notificationOptions = {
       title: 'Build Failed',
       subtitle: error.file,
       message: error.toString(),
       appIcon: path.resolve(__dirname, '..', 'ember-logo.png')
-    });
+    };
+    if(options && options.notificationOptions) {
+      notificationOptions = merge(notificationOptions, options.notificationOptions);
+    }
+    return notifier.notify(notificationOptions);
   }
 };

--- a/tests/unit/notifier-nodetest.js
+++ b/tests/unit/notifier-nodetest.js
@@ -21,12 +21,27 @@ describe('notifier', function() {
         return 'Something went wrong';
       }
     };
-    var notification = notifier.buildError(error, { notifier: fakeNodeNotifier });
+    var notification = notifier.buildError(error, { notifier: fakeNodeNotifier, notificationOptions: { sound: true } });
 
     expect(notification.title).to.equal('Build Failed');
     expect(notification.subtitle).to.equal(error.file);
     expect(notification.message).to.equal(error.toString());
     expect(notification.appIcon).to.include('ember-logo.png');
+    expect(notification.sound).to.equal(true);
+  });
+
+  it('allows settings in config to take precedence on build failure', function(){
+    notifier.nodeNotifier = fakeNodeNotifier;
+    var error = {
+      file: 'application.hbs',
+      toString: function() {
+        return 'Something went wrong';
+      }
+    };
+    var notification = notifier.buildError(error, { notifier: fakeNodeNotifier, notificationOptions: { subtitle: 'Test String' } });
+
+    expect(notification.title).to.equal('Build Failed');
+    expect(notification.subtitle).to.equal('Test String');
   });
 
   it('sends the correct options to node-notifier on build success', function(){
@@ -34,10 +49,22 @@ describe('notifier', function() {
     var results = {
       totalTime: 121000000
     };
-    var notification = notifier.buildSuccess(results, { notifier: fakeNodeNotifier });
+    var notification = notifier.buildSuccess(results, { notifier: fakeNodeNotifier, notificationOptions: { sound: true } });
 
     expect(notification.title).to.equal('Build Succeeded');
     expect(notification.message).to.equal('Build Time: 121ms');
     expect(notification.appIcon).to.include('ember-logo.png');
+    expect(notification.sound).to.equal(true);
+  });
+
+  it('allows settings in config to take precedence on build success', function(){
+    notifier.nodeNotifier = fakeNodeNotifier;
+    var results = {
+      totalTime: 121000000
+    };
+    var notification = notifier.buildSuccess(results, { notifier: fakeNodeNotifier, notificationOptions: { message: 'Test String' } });
+
+    expect(notification.title).to.equal('Build Succeeded');
+    expect(notification.message).to.equal('Test String');
   });
 });


### PR DESCRIPTION
node-notifier has lots of wonderful options we can change, so we should allow people to use them. This allows, for example, enabling of sounds, custom images and clickable notifications